### PR TITLE
Update nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ description = "Manages the Linux hardware clock through ioctls"
 [dependencies]
 chrono = "0.4.0"
 libc = "0.2.36"
-nix = "0.10.0"
+nix = "0.22.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,9 @@ mod ffi {
     use super::RtcTime;
 
     // ioctls, stolen from linux/rtc.h
-    ioctl!(read rtc_rd_time with 'p', 0x09; RtcTime);
-    ioctl!(write_ptr rtc_set_time with 'p', 0x0a; RtcTime);
+    const RTC_IOC_MAGIC: u8 = b'p';
+    ioctl_read!(rtc_rd_time, RTC_IOC_MAGIC, 0x09, RtcTime);
+    ioctl_write_ptr!(rtc_set_time, RTC_IOC_MAGIC, 0x0a, RtcTime);
 }
 
 /// Linux `struct rtc_time` wrapper


### PR DESCRIPTION
The old 0.10.0 nix did not compile on aarch64-unknown-linux-musl.
See https://github.com/nix-rust/nix/commit/7f0fb19f21327e58faa71dace73c8b092c25c81b
for the fix in nix.